### PR TITLE
Spiral edits

### DIFF
--- a/R/archimedean-spirals.r
+++ b/R/archimedean-spirals.r
@@ -67,12 +67,12 @@ sample_arch_spiral <- function(
 #' @rdname arch-spirals
 #' @export
 sample_swiss_roll <- function(
-  n, arms = 1L, min_wrap = 0, max_wrap = 1, width = 2*pi, sd = 0
+  n, ar = 1, arms = 1L, min_wrap = 0, max_wrap = 1, width = 2*pi, sd = 0
 ) {
   #Samples uniformly from the archimedian spiral on which the swiss roll is a
   #cylinder
   res <- sample_arch_spiral(
-    n = n, arms = arms, min_wrap = min_wrap, max_wrap = max_wrap,
+    n = n, ar = ar, arms = arms, min_wrap = min_wrap, max_wrap = max_wrap,
     sd = 0
   )
   #Augments the archimedian spiral sample with a third coordinate uniformly

--- a/R/archimedean-spirals.r
+++ b/R/archimedean-spirals.r
@@ -53,7 +53,10 @@ sample_arch_spiral <- function(
       list(res[arm == 0L, , drop = FALSE]),
       lapply(seq(arms - 1L), function(i) {
         res[arm == i, , drop = FALSE] %*%
-          matrix(c(cos(rot[i]), sin(rot[i]), -sin(rot[i]), cos(rot[i])), nrow = 2)
+          matrix(
+            c(cos(rot[i]), sin(rot[i]), -sin(rot[i]), cos(rot[i])),
+            nrow = 2
+          )
       })
     ))
   }

--- a/R/archimedean-spirals.r
+++ b/R/archimedean-spirals.r
@@ -23,6 +23,7 @@
 
 #' @name arch-spirals
 #' @param n Number of observations.
+#' @param ar Aspect ratio of spiral (ratio of width/height)
 #' @param arms Number of spiral arms.
 #' @param min_wrap The wrap of the spiral from which sampling begins.
 #' @param max_wrap The wrap of the spiral at which sampling ends.
@@ -35,12 +36,12 @@ NULL
 #' @rdname arch-spirals
 #' @export
 sample_arch_spiral <- function(
-  n, arms = 1L, min_wrap = 0, max_wrap = 1, sd = 0
+  n, ar = 1, arms = 1L, min_wrap = 0, max_wrap = 1, sd = 0
 ) {
   theta <- rs_spiral(n, min_wrap, max_wrap)
   #Applies modified theta values to parametric equation of spiral
   res <- cbind(
-    x = (theta * cos(theta)),
+    x = ar * (theta * cos(theta)),
     y = (theta * sin(theta))
   )
   #Partitions the sample into arms and rotates each accordingly

--- a/R/archimedean-spirals.r
+++ b/R/archimedean-spirals.r
@@ -88,12 +88,20 @@ rs_spiral <- function(n, min_wrap, max_wrap){
   #Keep looping until desired number of observations is achieved
   while(length(x) < n){
     theta <- runif(n, min_theta, max_theta)
+    jacobian <- jd_spiral()
+    #Applies the jacobian scalar value to each value of theta
+    jacobian_theta <- sapply(theta, jacobian)
     #Density threshold is the greatest jacobian value in the spiral, and the
     #area of least warping
     density_threshold <- runif(n, 0, max_theta)
     #Takes theta values that exceed the density threshold, and throws out the
     #rest
-    x <- c(x, theta[theta > density_threshold])
+    x <- c(x, theta[jacobian_theta > density_threshold])
   }
   x[1:n]
+}
+
+#Jacobian determinant of archimedean spiral
+jd_spiral <- function() {
+  function(theta) sqrt(1 + theta^2)
 }

--- a/inst/examples/ex-archimedean-spirals.r
+++ b/inst/examples/ex-archimedean-spirals.r
@@ -2,6 +2,16 @@
 x <- sample_arch_spiral(360, min_wrap = 0, max_wrap = 1)
 plot(x, asp = 1, pch = 19, cex = .5)
 
+#Uniformly sampled archimedean spiral in 2-space, with 1 wrap 
+#and aspect ratio of 2:1
+x <- sample_arch_spiral(360, ar = 2, min_wrap = 0, max_wrap = 1)
+plot(x, asp = 1, pch = 19, cex = .5)
+
+#Uniformly sampled archimedean spiral in 2-space, with 1 wrap 
+#and aspect ratio of 1:2
+x <- sample_arch_spiral(360, ar = 0.5, min_wrap = 0, max_wrap = 1)
+plot(x, asp = 1, pch = 19, cex = .5)
+
 #Uniformly sampled archimedean spiral in 2-space, with 5 wraps
 x <- sample_arch_spiral(360, min_wrap = 0, max_wrap = 5)
 plot(x, asp = 1, pch = 19, cex = .5)

--- a/inst/examples/ex-archimedean-spirals.r
+++ b/inst/examples/ex-archimedean-spirals.r
@@ -35,3 +35,9 @@ x <- sample_swiss_roll(720, width = 2*pi)
 pairs(x, asp = 1, pch = 19, cex = .5)
 pca <- prcomp(x)
 plot(x %*% pca$rotation, asp = 1, pch = 19, cex = .5)
+
+#Uniformly sampled swiss roll in 3-space, from 0 to 1 wraps and width 2*pi
+x <- sample_swiss_roll(720, ar = 2, width = 2*pi)
+pairs(x, asp = 1, pch = 19, cex = .5)
+pca <- prcomp(x)
+plot(x %*% pca$rotation, asp = 1, pch = 19, cex = .5)

--- a/man/arch-spirals.Rd
+++ b/man/arch-spirals.Rd
@@ -9,7 +9,7 @@
 sample_arch_spiral(n, ar = 1, arms = 1L, min_wrap = 0,
   max_wrap = 1, sd = 0)
 
-sample_swiss_roll(n, arms = 1L, min_wrap = 0, max_wrap = 1,
+sample_swiss_roll(n, ar = 1, arms = 1L, min_wrap = 0, max_wrap = 1,
   width = 2 * pi, sd = 0)
 }
 \arguments{
@@ -79,6 +79,12 @@ plot(x, asp = 1, pch = 19, cex = .5)
 
 #Uniformly sampled swiss roll in 3-space, from 0 to 1 wraps and width 2*pi
 x <- sample_swiss_roll(720, width = 2*pi)
+pairs(x, asp = 1, pch = 19, cex = .5)
+pca <- prcomp(x)
+plot(x \%*\% pca$rotation, asp = 1, pch = 19, cex = .5)
+
+#Uniformly sampled swiss roll in 3-space, from 0 to 1 wraps and width 2*pi
+x <- sample_swiss_roll(720, ar = 2, width = 2*pi)
 pairs(x, asp = 1, pch = 19, cex = .5)
 pca <- prcomp(x)
 plot(x \%*\% pca$rotation, asp = 1, pch = 19, cex = .5)

--- a/man/arch-spirals.Rd
+++ b/man/arch-spirals.Rd
@@ -6,14 +6,16 @@
 \alias{sample_swiss_roll}
 \title{Sample (with noise) from archimedean spirals and swiss rolls}
 \usage{
-sample_arch_spiral(n, arms = 1L, min_wrap = 0, max_wrap = 1,
-  sd = 0)
+sample_arch_spiral(n, ar = 1, arms = 1L, min_wrap = 0,
+  max_wrap = 1, sd = 0)
 
 sample_swiss_roll(n, arms = 1L, min_wrap = 0, max_wrap = 1,
   width = 2 * pi, sd = 0)
 }
 \arguments{
 \item{n}{Number of observations.}
+
+\item{ar}{Aspect ratio of spiral (ratio of width/height)}
 
 \item{arms}{Number of spiral arms.}
 
@@ -45,6 +47,16 @@ archimedian spiral sampler.
 \examples{
 #Uniformly sampled archimedean spiral in 2-space, with 1 wrap
 x <- sample_arch_spiral(360, min_wrap = 0, max_wrap = 1)
+plot(x, asp = 1, pch = 19, cex = .5)
+
+#Uniformly sampled archimedean spiral in 2-space, with 1 wrap 
+#and aspect ratio of 2:1
+x <- sample_arch_spiral(360, ar = 2, min_wrap = 0, max_wrap = 1)
+plot(x, asp = 1, pch = 19, cex = .5)
+
+#Uniformly sampled archimedean spiral in 2-space, with 1 wrap 
+#and aspect ratio of 1:2
+x <- sample_arch_spiral(360, ar = 0.5, min_wrap = 0, max_wrap = 1)
 plot(x, asp = 1, pch = 19, cex = .5)
 
 #Uniformly sampled archimedean spiral in 2-space, with 5 wraps


### PR DESCRIPTION
I modified `sample_arch_spiral()` to include the correct jacobian expression within the rejection sampling process, as well as an aspect ratio. Documentation and demonstrative examples edited accordingly (though I forgot the command to process the documentation through ROxygen).

This closes #15 